### PR TITLE
Fix Segmentation fault on interfaces with null ifa_addr.

### DIFF
--- a/mcproxy/src/utils/if_prop.cpp
+++ b/mcproxy/src/utils/if_prop.cpp
@@ -57,7 +57,7 @@ bool if_prop::refresh_network_interfaces()
 
     struct ifaddrs* ifEntry = nullptr;
     for (ifEntry = m_if_addrs; ifEntry != nullptr; ifEntry = ifEntry->ifa_next) {
-        if (ifEntry->ifa_addr->sa_data == nullptr) {
+        if (ifEntry->ifa_addr == nullptr || ifEntry->ifa_addr->sa_data == nullptr) {
             continue;
         }
 


### PR DESCRIPTION
This fixes refreshing of interfaces with null ifa_addr (PPP interfaces on OpenWrt).
