### PR TITLE
Allow disabling mcproxy in the config.

### DIFF
--- a/mcproxy/include/parser/token.hpp
+++ b/mcproxy/include/parser/token.hpp
@@ -50,6 +50,7 @@ enum token_type {
     TT_ALL,
     TT_FIRST,
     TT_MUTEX,
+    TT_DISABLE,
     //TT_MILLISECONDS, //@milliseconds@
     //TT_TABLE_NAME, //@table_name@
     //TT_PATH, //@path@

--- a/mcproxy/src/parser/parser.cpp
+++ b/mcproxy/src/parser/parser.cpp
@@ -36,7 +36,6 @@ parser::parser(unsigned int current_line, const std::string& cmd)
 
 parser_type parser::get_parser_type()
 {
-
     if (m_current_token.get_type() == TT_PROTOCOL) {
         return PT_PROTOCOL;
     } else if (m_current_token.get_type() == TT_TABLE) {
@@ -51,6 +50,8 @@ parser_type parser::get_parser_type()
             HC_LOG_ERROR("failed to parse line " << m_current_line << " unknown token " << get_token_type_name(cmp_token.get_type()) << " with value " << cmp_token.get_string() << ", expected \":\" or \"upstream\" or \"downstream\"");
             throw "failed to parse config file";
         }
+    } else if(m_current_token.get_type() == TT_DISABLE) {
+        throw "mcproxy is disabled";
     } else {
         HC_LOG_ERROR("failed to parse line " << m_current_line << " unknown token " << get_token_type_name(m_current_token.get_type()) << " with value " << m_current_token.get_string());
         throw "failed to parse config file";

--- a/mcproxy/src/parser/scanner.cpp
+++ b/mcproxy/src/parser/scanner.cpp
@@ -188,6 +188,8 @@ token scanner::read_next_token()
                 return TT_FIRST;
             } else if (cmp_str.compare("mutex") == 0) {
                 return TT_MUTEX;
+            } else if (cmp_str.compare("disable") == 0) {
+                return TT_DISABLE;
             } else {
                 return token(TT_STRING, s.str());
             }


### PR DESCRIPTION
This is needed for OpenWrt, since mcproxy will try to run with a default configuration, even if the supplied config is completely blank.
On OpenWrt if the package is installed and not configured, we don't want it to be running at all.
