### PR TITLE
Work around GCC bug 55856

### DIFF
--- a/mcproxy/src/proxy/simple_mc_proxy_routing.cpp
+++ b/mcproxy/src/proxy/simple_mc_proxy_routing.cpp
@@ -153,10 +153,10 @@ void interface_memberships::process_upstream_in_mutex(const addr_storage& gaddr,
 {
     HC_LOG_TRACE("");
 
-    std::list<std::pair<source_state, const std::shared_ptr<const interface>>> ref_sstate_list;
+    std::list<std::pair<source_state, const std::shared_ptr<interface>>> ref_sstate_list;
 
     for (auto & downs_e : pi->m_downstreams) {
-        ref_sstate_list.push_back(std::pair<source_state, const std::shared_ptr<const interface>&>(source_state(downs_e.second.m_querier->get_group_membership_infos(gaddr)), downs_e.second.m_interface));
+        ref_sstate_list.push_back(std::pair<source_state, const std::shared_ptr<interface>&>(source_state(downs_e.second.m_querier->get_group_membership_infos(gaddr)), downs_e.second.m_interface));
     }
 
     //init and fill database


### PR DESCRIPTION
Work around an internal compiler error of GCC by preventing the
std::pair from being turned into a constexpr.

Feel free to wontfix-close this pull request, I only made it so others might find this solution to compile mcproxy without having to update their compiler.

Error message: "internal compiler error: in build_data_member_initialization, at cp/semantics.c:5790"
http://gcc.gnu.org/bugzilla/show_bug.cgi?id=55856
