### PR TITLE
Fixes and edits to support use on openwrt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 2.8)
+
+# Project Definition
+project(mcproxy CXX)
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11")
+add_definitions(-Wall -Wextra -pedantic)
+include_directories(${CMAKE_SOURCE_DIR}/mcproxy)
+
+
+add_executable(mcproxy-bin mcproxy/src/main.cpp 
+           mcproxy/src/hamcast_logging.cpp 
+               #utils
+           mcproxy/src/utils/mc_socket.cpp 
+           mcproxy/src/utils/addr_storage.cpp 
+           mcproxy/src/utils/mroute_socket.cpp 
+           mcproxy/src/utils/if_prop.cpp 
+           mcproxy/src/utils/reverse_path_filter.cpp 
+               #proxy
+           mcproxy/src/proxy/proxy.cpp 
+           mcproxy/src/proxy/sender.cpp 
+           mcproxy/src/proxy/receiver.cpp 
+           mcproxy/src/proxy/mld_receiver.cpp 
+           mcproxy/src/proxy/igmp_receiver.cpp 
+           mcproxy/src/proxy/mld_sender.cpp 
+           mcproxy/src/proxy/igmp_sender.cpp 
+           mcproxy/src/proxy/proxy_instance.cpp 
+           mcproxy/src/proxy/routing.cpp 
+           mcproxy/src/proxy/worker.cpp 
+           mcproxy/src/proxy/timing.cpp 
+           mcproxy/src/proxy/check_if.cpp 
+           mcproxy/src/proxy/check_kernel.cpp 
+           mcproxy/src/proxy/membership_db.cpp 
+           mcproxy/src/proxy/querier.cpp 
+           mcproxy/src/proxy/timers_values.cpp 
+           mcproxy/src/proxy/interfaces.cpp 
+           mcproxy/src/proxy/def.cpp 
+           mcproxy/src/proxy/simple_mc_proxy_routing.cpp 
+           mcproxy/src/proxy/simple_routing_data.cpp 
+               #parser
+           mcproxy/src/parser/scanner.cpp 
+           mcproxy/src/parser/token.cpp 
+           mcproxy/src/parser/configuration.cpp 
+           mcproxy/src/parser/parser.cpp 
+           mcproxy/src/parser/interface.cpp
+)
+target_link_libraries(mcproxy-bin pthread)
+
+# Installation
+install(TARGETS mcproxy-bin DESTINATION bin/)
+
+

--- a/mcproxy/include/parser/parser.hpp
+++ b/mcproxy/include/parser/parser.hpp
@@ -56,6 +56,8 @@ private:
 
     void parse_interface_rule_match_binding(std::string&& instance_name, rb_interface_type interface_type, std::string&& if_name, rb_interface_direction filter_direction, const inst_def_set& ids);
 
+    void parse_interface_name(std::string& if_name);
+
 public:
     parser(unsigned int current_line, const std::string& cmd);
     parser_type get_parser_type();

--- a/mcproxy/include/proxy/proxy.hpp
+++ b/mcproxy/include/proxy/proxy.hpp
@@ -46,7 +46,7 @@ class proxy_instance;
 class proxy
 {
 private:
-    static bool m_running;
+    static volatile bool m_running;
     int m_verbose_lvl;
     bool m_print_proxy_status;
     bool m_reset_rp_filter;

--- a/mcproxy/include/utils/mroute_socket.hpp
+++ b/mcproxy/include/utils/mroute_socket.hpp
@@ -34,7 +34,7 @@
 #define MROUTE_TTL_THRESHOLD 1
 #define MROUTE_DEFAULT_TTL 1
 
-#define ADD_SIGNED_NUM_U16(r,a) (r)+= (a); (r)+= ((r)>>16)
+#define ADD_SIGNED_NUM_U16(r,a) (r)+= (a); (r) = (((r)&0xffff) + ((r)>>16))
 
 /**
  * @brief Wrapper for a multicast socket with additional functions to manipulate Linux kernel tables.

--- a/mcproxy/src/hamcast_logging.cpp
+++ b/mcproxy/src/hamcast_logging.cpp
@@ -102,7 +102,7 @@ public:
             break;
         }
         os.width(80);
-        os << std::left << fun;
+        os << std::left << fun << ": ";
         os.width(0);
         os << what;
         os << "\n";

--- a/mcproxy/src/proxy/igmp_receiver.cpp
+++ b/mcproxy/src/proxy/igmp_receiver.cpp
@@ -32,6 +32,7 @@
 #include <netinet/ip.h>
 
 #ifdef DEBUG_MODE
+#include <stdio.h>
 extern "C" {
 void print_buf(const unsigned char * buf, unsigned int size)
 {

--- a/mcproxy/src/proxy/interfaces.cpp
+++ b/mcproxy/src/proxy/interfaces.cpp
@@ -66,8 +66,22 @@ bool interfaces::add_interface(unsigned int if_index)
     HC_LOG_DEBUG("if_index: " << if_index << " (" << interfaces::get_if_name(if_index) << ")" << " free_vif: " << free_vif);
     if (free_vif > INTERFACES_UNKOWN_VIF_INDEX) {
         if (!is_interface(if_index, IFF_UP)) {
-            HC_LOG_WARN("failed to add interface: " << get_if_name(if_index) << "; interface is not up");
+            HC_LOG_WARN("interface is not up: " << get_if_name(if_index));
+            // TBD: should the interface-up check be optional with config?
+            // Issue: in my home router on openwrt, this failed to start
+            // because the upstream interface wasn't plugged in. However, it
+            // works ok if it starts plugged in, then gets unplugged, then
+            // plugged in later. It also works ok if we just disable this
+            // check, and plug it in later. So I think we need a mode to run
+            // without this check.
+            // I think it's best just gone, but maybe some use case
+            // justifies having this optional according to config input?
+            // If you ever debug your way to here wishing it had refused
+            // to run instead of issuing a warning, send me an email please.
+            // -Jake 2017-04-19
+            /*
             return false;
+            */
         }
 
         auto rc_if_vif = m_if_vif.insert(std::pair<int, int>(if_index, free_vif));

--- a/mcproxy/src/proxy/proxy.cpp
+++ b/mcproxy/src/proxy/proxy.cpp
@@ -37,7 +37,7 @@
 #include <signal.h>
 #include <unistd.h>
 
-bool proxy::m_running = false;
+volatile bool proxy::m_running = false;
 
 proxy::proxy(int arg_count, char* args[])
     : m_verbose_lvl(0)

--- a/mcproxy/src/tester/tester.cpp
+++ b/mcproxy/src/tester/tester.cpp
@@ -27,6 +27,7 @@
 #include "include/proxy/interfaces.hpp"
 
 #include <cstring>
+#include <cstdlib>
 #include <thread>
 #include <csignal>
 #include <vector>
@@ -356,7 +357,7 @@ std::chrono::milliseconds tester::get_send_interval(const std::string& to_do)
         interval = 1000; //milliseconds
     } else {
         try {
-            interval = std::stoi(str_interval);
+            interval = std::atoi(str_interval.c_str());
         } catch (std::logic_error e) {
             std::cout << "failed to parse interval" << std::endl;
             exit(0);
@@ -375,7 +376,7 @@ std::chrono::milliseconds tester::get_lifetime(const std::string& to_do)
         lifetime = 0; //endless
     } else {
         try {
-            lifetime = std::stoi(str_lifetime);
+            lifetime = std::atoi(str_lifetime.c_str());
         } catch (std::logic_error e) {
             std::cout << "failed to parse lifetime" << std::endl;
             exit(0);
@@ -393,7 +394,7 @@ int tester::get_int(const std::string& to_do, std::string&& compare, int default
         return default_return;
     } else {
         try {
-            return std::stoi(result);
+            return std::atoi(result.c_str());
         } catch (std::logic_error e) {
             std::cout << "failed to parse " << compare << std::endl;
             exit(0);

--- a/mcproxy/src/utils/addr_storage.cpp
+++ b/mcproxy/src/utils/addr_storage.cpp
@@ -25,6 +25,7 @@
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <stdlib.h>
@@ -298,7 +299,7 @@ addr_storage& addr_storage::set_port(uint16_t port)
 
 addr_storage& addr_storage::set_port(const std::string& port)
 {
-    set_port(std::stoi(port.c_str()));
+    set_port(std::atoi(port.c_str()));
     return *this;
 }
 

--- a/mcproxy/src/utils/mc_socket.cpp
+++ b/mcproxy/src/utils/mc_socket.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <memory> //unique_ptr
 #include <netinet/in.h>
+#include <netinet/ip.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/socket.h>
@@ -36,6 +37,13 @@
 #include <net/if.h>
 #include <numeric>
 #include <unistd.h>
+#include <string>
+
+#ifdef __UCLIBC__
+#define IP_MULTICAST_ALL 49
+
+#include "sourcefilter.cpp"
+#endif /* __UCLIBC__ */
 
 std::string ipAddrResolver(std::string ipAddr)
 {

--- a/mcproxy/src/utils/mroute_socket.cpp
+++ b/mcproxy/src/utils/mroute_socket.cpp
@@ -774,14 +774,14 @@ bool mroute_socket::get_mroute_stats(const addr_storage& source_addr, const addr
 
             rc = ioctl(m_sock, SIOCGETSGCNT, sgreq_v4);;
             if (rc == -1) {
-                HC_LOG_ERROR("failed to get multicast route stats! Error: " << strerror(errno) << " errno: " << errno);
+                HC_LOG_ERROR("failed to get multicast route stats for (" << source_addr.to_string() << "," << group_addr.to_string() <<")! Error: " << strerror(errno) << " errno: " << errno);
                 return false;
             } else {
                 return true;
             }
 
         } else {
-            HC_LOG_ERROR("failed to get multicast route stats! Error: claimed parameter sgreq_v4 is null");
+            HC_LOG_ERROR("failed to get multicast route stats for (" << source_addr.to_string() << "," << group_addr.to_string() <<")! Error: claimed parameter sgreq_v4 is null");
             return false;
         }
     } else if (m_addrFamily == AF_INET6) {
@@ -793,13 +793,13 @@ bool mroute_socket::get_mroute_stats(const addr_storage& source_addr, const addr
 
             rc = ioctl(m_sock, SIOCGETSGCNT_IN6, sgreq_v6);
             if (rc == -1) {
-                HC_LOG_ERROR("failed to get multicast route stats! Error: " << strerror(errno) << " errno: " << errno);
+                HC_LOG_ERROR("failed to get multicast route stats for (" << source_addr.to_string() << "," << group_addr.to_string() <<")! Error: " << strerror(errno) << " errno: " << errno);
                 return false;
             } else {
                 return true;
             }
         } else {
-            HC_LOG_ERROR("failed to get multicast route stats! Error: claimed parameter sgreq_v6 is null");
+            HC_LOG_ERROR("failed to get multicast route stats for (" << source_addr.to_string() << "," << group_addr.to_string() <<")! Error: claimed parameter sgreq_v6 is null");
             return false;
         }
     } else {

--- a/mcproxy/src/utils/sourcefilter.cpp
+++ b/mcproxy/src/utils/sourcefilter.cpp
@@ -1,0 +1,166 @@
+/* Get source filter.  Linux version.
+   Copyright (C) 2004-2014 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2004.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <netinet/in.h>
+#include <netpacket/packet.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+
+static const struct
+{
+  int sol;
+  int af;
+  socklen_t size;
+}  sol_map[] =
+  {
+    /* Sort the array according to importance of the protocols.  Add
+       more protocols when they become available.  */
+    { SOL_IP, AF_INET, sizeof (struct sockaddr_in) },
+    { SOL_IPV6, AF_INET6, sizeof (struct sockaddr_in6) },
+    { SOL_PACKET, AF_PACKET, sizeof (struct sockaddr_ll) }
+  };
+#define NSOL_MAP (sizeof (sol_map) / sizeof (sol_map[0]))
+
+
+/* Try to determine the socket level value.  Ideally both side and
+   family are set.  But sometimes only the size is correct and the
+   family value might be bogus.  Loop over the array entries and look
+   for a perfect match or the first match based on size.  */
+static int
+__get_sol (int af, socklen_t len)
+{
+  int first_size_sol = -1;
+
+  for (size_t cnt = 0; cnt < NSOL_MAP; ++cnt)
+    {
+      /* Just a test so that we make sure the special value used to
+	 signal the "we have so far no socket level value" is OK.  */
+      assert (sol_map[cnt].sol != -1);
+
+      if (len == sol_map[cnt].size)
+	{
+	  /* The size matches, which is a requirement.  If the family
+	     matches, too, we have a winner.  Otherwise we remember the
+	     socket level value for this protocol if it is the first
+	     match.  */
+	  if (af == sol_map[cnt].af)
+	    /* Bingo!  */
+	    return sol_map[cnt].sol;
+
+	  if (first_size_sol == -1)
+	    first_size_sol = sol_map[cnt].sol;
+      }
+    }
+
+  return first_size_sol;
+}
+
+
+int
+getsourcefilter (int s, uint32_t interface, const struct sockaddr *group,
+		 socklen_t grouplen, uint32_t *fmode, uint32_t *numsrc,
+		 struct sockaddr_storage *slist)
+{
+  /* We have to create an struct ip_msfilter object which we can pass
+     to the kernel.  */
+  socklen_t needed = GROUP_FILTER_SIZE (*numsrc);
+  struct group_filter *gf;
+  gf = (struct group_filter *) malloc (needed);
+  if (gf == NULL)
+    return -1;
+
+  gf->gf_interface = interface;
+  memcpy (&gf->gf_group, group, grouplen);
+  gf->gf_numsrc = *numsrc;
+
+  /* We need to provide the appropriate socket level value.  */
+  int result;
+  int sol = __get_sol (group->sa_family, grouplen);
+  if (sol == -1)
+    {
+      errno = EINVAL;
+      result = -1;
+    }
+  else
+    {
+      result = getsockopt (s, sol, MCAST_MSFILTER, gf, &needed);
+
+      /* If successful, copy the results to the places the caller wants
+	 them in.  */
+      if (result == 0)
+	{
+	  *fmode = gf->gf_fmode;
+	  memcpy (slist, gf->gf_slist,
+		  MIN (*numsrc, gf->gf_numsrc)
+		  * sizeof (struct sockaddr_storage));
+	  *numsrc = gf->gf_numsrc;
+	}
+    }
+
+    int save_errno = errno;
+    free (gf);
+    errno = save_errno;
+
+  return result;
+}
+
+
+int
+setsourcefilter (int s, uint32_t interface, const struct sockaddr *group,
+		 socklen_t grouplen, uint32_t fmode, uint32_t numsrc,
+		 const struct sockaddr_storage *slist)
+{
+  /* We have to create an struct ip_msfilter object which we can pass
+     to the kernel.  */
+  size_t needed = GROUP_FILTER_SIZE (numsrc);
+
+  struct group_filter *gf;
+  gf = (struct group_filter *) malloc (needed);
+  if (gf == NULL)
+    return -1;
+
+  gf->gf_interface = interface;
+  memcpy (&gf->gf_group, group, grouplen);
+  gf->gf_fmode = fmode;
+  gf->gf_numsrc = numsrc;
+  memcpy (gf->gf_slist, slist, numsrc * sizeof (struct sockaddr_storage));
+
+  /* We need to provide the appropriate socket level value.  */
+  int result;
+  int sol = __get_sol (group->sa_family, grouplen);
+  if (sol == -1)
+    {
+      errno = EINVAL;
+      result = -1;
+    }
+  else
+    result = setsockopt (s, sol, MCAST_MSFILTER, gf, needed);
+
+    int save_errno = errno;
+    free (gf);
+    errno = save_errno;
+
+  return result;
+}
+


### PR DESCRIPTION
Many of the patches are a direct application of the patches in mcproxy-openwrt:
https://github.com/openwrt-routing/packages/tree/master/mcproxy/patches

The 2 main exceptions are editing the interface name parsing to accept dashes and dots, and the checksum fix.

Even if you reject the openwrt changes, I encourage you to cherry-pick the checksum fix.