### PR TITLE
mcproxy: Add support for multiple versions of queries.

### DIFF
--- a/mcproxy/include/proxy/igmp_sender.hpp
+++ b/mcproxy/include/proxy/igmp_sender.hpp
@@ -36,10 +36,12 @@
 class igmp_sender : public sender
 {
 private:
+    group_mem_protocol m_group_mem_protocol;
     bool send_igmpv3_query(unsigned int if_index, const timers_values& tv, const addr_storage& gaddr, bool s_flag, const source_list<source>& slist) const;
+    bool send_igmp_query(unsigned int if_index, const timers_values& tv, const addr_storage& gaddr) const;
 
 public:
-    igmp_sender(const std::shared_ptr<const interfaces>& interfaces);
+    igmp_sender(const std::shared_ptr<const interfaces>& interfaces,  group_mem_protocol  group_mem_protocol);
 
     bool send_record(unsigned int if_index, mc_filter filter_mode, const addr_storage& gaddr, const source_list<source>& slist) const override;
 

--- a/mcproxy/src/proxy/proxy_instance.cpp
+++ b/mcproxy/src/proxy/proxy_instance.cpp
@@ -119,7 +119,7 @@ bool proxy_instance::init_sender()
 {
     HC_LOG_TRACE("");
     if (is_IPv4(m_group_mem_protocol)) {
-        m_sender = std::make_shared<igmp_sender>(m_interfaces);
+        m_sender = std::make_shared<igmp_sender>(m_interfaces, m_group_mem_protocol);
     } else if (is_IPv6(m_group_mem_protocol)) {
         m_sender = std::make_shared<mld_sender>(m_interfaces);
     } else {


### PR DESCRIPTION
Currently always v3 queries are sent. This breaks functionality
of igmp when hosts don't support v3. This is easily reproducible
with macbook as one of the host and a v3 query is sent to the macbook,
causing it to ignore it since it doesn't accept it when its configured
for v2.
More information here:
https://serverfault.com/questions/819793/os-x-network-stack-ignores-igmp-membership-queries